### PR TITLE
#76 Created classes required to display the dashboard.

### DIFF
--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/DashboardDisplaySystem.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/DashboardDisplaySystem.java
@@ -1,0 +1,19 @@
+package hu.oe.nik.szfmv.automatedcar.systemcomponents;
+
+import hu.oe.nik.szfmv.automatedcar.bus.VirtualFunctionBus;
+import hu.oe.nik.szfmv.visualization.Dashboard;
+
+public class DashboardDisplaySystem extends SystemComponent {
+
+    private Dashboard dashboard;
+
+    protected DashboardDisplaySystem(VirtualFunctionBus virtualFunctionBus, Dashboard dashboard) {
+        super(virtualFunctionBus);
+        this.dashboard = dashboard;
+    }
+
+    @Override
+    public void loop() {
+        dashboard.UpdateDisplayedValues();
+    }
+}

--- a/src/main/java/hu/oe/nik/szfmv/visualization/Dashboard.java
+++ b/src/main/java/hu/oe/nik/szfmv/visualization/Dashboard.java
@@ -16,11 +16,20 @@ public class Dashboard extends JPanel {
      * Initialize the dashboard
      */
     public Dashboard() {
+        InitializeDashboard();
+    }
+
+    /**
+     * Update the displayed values
+     */
+    public void UpdateDisplayedValues() {
+
+    }
+
+    private void InitializeDashboard() {
         // Not using any layout manager, but fixed coordinates
         setLayout(null);
         setBackground(new Color(backgroundColor));
         setBounds(770, 0, width, height);
-
     }
-
 }


### PR DESCRIPTION
#76 Created classes required to display the dashboard
- Moved the JPanel initialization from Dashboard's constructor to a separate method to prepare for the rest of the needed initializations.

- Added UpdateDisplayedValues method which will update the currently displayed dashboard values.

- Created DashboardDisplaySystem system component which will get the needed data from the VFB and will pass it to the UpdateDisplayedValues method. Currently, this method requires no parameters because the needed packets do not exist yet.
