### PR TITLE
Team4 sprint2 143 powertrain display

### DIFF
--- a/src/main/java/hu/oe/nik/szfmv/Main.java
+++ b/src/main/java/hu/oe/nik/szfmv/Main.java
@@ -50,7 +50,8 @@ public class Main {
                 pedestrian.moveOnCrosswalk();
 
                 gui.getCourseDisplay().drawWorld(w, car.getCarValues());
-                gui.getDashboard().updateDisplayedValues(car.getInputValues(), car.getX(), car.getY());
+                gui.getDashboard().updateDisplayedValues(car.getInputValues(), car.getPowertrainValues(),
+                        car.getX(), car.getY());
                 Thread.sleep(CYCLE_PERIOD);
             } catch (InterruptedException e) {
                 LOGGER.error(e.getMessage());

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/AutomatedCar.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/AutomatedCar.java
@@ -4,6 +4,7 @@ import hu.oe.nik.szfmv.automatedcar.bus.VirtualFunctionBus;
 import hu.oe.nik.szfmv.automatedcar.bus.exception.MissingPacketException;
 import hu.oe.nik.szfmv.automatedcar.bus.packets.car.CarPacket;
 import hu.oe.nik.szfmv.automatedcar.bus.packets.input.ReadOnlyInputPacket;
+import hu.oe.nik.szfmv.automatedcar.bus.powertrain.ReadOnlyPowertrainPacket;
 import hu.oe.nik.szfmv.automatedcar.systemcomponents.*;
 import hu.oe.nik.szfmv.environment.WorldObject;
 import org.apache.logging.log4j.LogManager;
@@ -130,4 +131,12 @@ public class AutomatedCar extends WorldObject {
         return virtualFunctionBus.carPacket;
     }
 
+    /**
+     * Gets the powertrain values as required by the dashboard.
+     *
+     * @return powertrain packet containing the values that are displayed on the dashboard
+     */
+    public ReadOnlyPowertrainPacket getPowertrainValues() {
+        return virtualFunctionBus.powertrainPacket;
+    }
 }

--- a/src/main/java/hu/oe/nik/szfmv/visualization/Dashboard.java
+++ b/src/main/java/hu/oe/nik/szfmv/visualization/Dashboard.java
@@ -1,5 +1,6 @@
 package hu.oe.nik.szfmv.visualization;
 
+import hu.oe.nik.szfmv.automatedcar.bus.powertrain.ReadOnlyPowertrainPacket;
 import hu.oe.nik.szfmv.automatedcar.input.enums.GearEnum;
 import hu.oe.nik.szfmv.environment.models.RoadSign;
 
@@ -188,11 +189,13 @@ public class Dashboard extends JPanel {
     /**
      * Update the displayed values
      *
+     * @param powertrainPacket Contains all the required values coming from the powertrain.
      * @param inputPacket Contains all the required values coming from input.
      * @param carX        is the X coordinate of the car object
      * @param carY        is the Y coordinate of the car object
      */
-    public void updateDisplayedValues(ReadOnlyInputPacket inputPacket, int carX, int carY) {
+    public void updateDisplayedValues(ReadOnlyInputPacket inputPacket,
+                                      ReadOnlyPowertrainPacket powertrainPacket, int carX, int carY) {
         if (inputPacket != null) {
             updateProgressBars(inputPacket.getGasPedalPosition(), inputPacket.getBreakPedalPosition());
             updateGear(inputPacket.getGearState());
@@ -202,8 +205,10 @@ public class Dashboard extends JPanel {
             updateParkingPilotIndicator(inputPacket.getParkingPilotStatus());
             updateLaneKeepingIndicator(inputPacket.getLaneKeepingStatus());
         }
-        updateAnalogMeters(0, 0);
-        repaint();
+        if (powertrainPacket != null) {
+            updateAnalogMeters((int)powertrainPacket.getSpeed(), powertrainPacket.getRpm());
+            repaint();
+        }
         updateCarPositionLabel(carX, carY);
     }
 

--- a/src/test/java/hu/oe/nik/szfmv/visualization/DashboardTest.java
+++ b/src/test/java/hu/oe/nik/szfmv/visualization/DashboardTest.java
@@ -1,6 +1,8 @@
 package hu.oe.nik.szfmv.visualization;
 
 import hu.oe.nik.szfmv.automatedcar.bus.packets.input.ReadOnlyInputPacket;
+import hu.oe.nik.szfmv.automatedcar.bus.powertrain.PowertrainPacket;
+import hu.oe.nik.szfmv.automatedcar.bus.powertrain.ReadOnlyPowertrainPacket;
 import hu.oe.nik.szfmv.automatedcar.input.enums.GearEnum;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,6 +23,8 @@ public class DashboardTest {
     private boolean rightTurnSignalGetterCalled = false;
     private boolean steeringWheelGetterCalled = false;
     private boolean gearStateGetterCalled = false;
+    private boolean rpmGetterCalled = false;
+    private boolean speedGetterCalled = false;
 
     /**
      * Sets all the boolean values that indicate method calls to false before the tests are run.
@@ -35,6 +39,8 @@ public class DashboardTest {
         speedLabelGetterCalled = false;
         gearStateGetterCalled = false;
         steeringWheelGetterCalled = false;
+        rpmGetterCalled = false;
+        speedGetterCalled = false;
     }
 
     /**
@@ -43,9 +49,10 @@ public class DashboardTest {
     @Test
     public void allRequiredValuesReceivedOnUpdate() {
         InputPacketStub inputPacket = new InputPacketStub();
+        PowertrainPacketStub powertrainPacket = new PowertrainPacketStub();
         int carX = 0;
         int carY = 0;
-        dashboard.updateDisplayedValues(inputPacket, carX, carY);
+        dashboard.updateDisplayedValues(inputPacket, powertrainPacket, carX, carY);
 
         assertThat(gasPedalGetterCalled, is(true));
         assertThat(breakPedalGetterCalled, is(true));
@@ -57,6 +64,22 @@ public class DashboardTest {
         assertThat(leftTurnSignalGetterCalled, is(true));
         assertThat(rightTurnSignalGetterCalled, is(true));
         assertThat(steeringWheelGetterCalled, is(true));
+        assertThat(rpmGetterCalled, is(true));
+        assertThat(speedGetterCalled, is(true));
+    }
+
+    class PowertrainPacketStub implements ReadOnlyPowertrainPacket {
+        @Override
+        public int getRpm() {
+            rpmGetterCalled = true;
+            return 0;
+        }
+
+        @Override
+        public double getSpeed() {
+            speedGetterCalled = true;
+            return 0;
+        }
     }
 
     class InputPacketStub implements ReadOnlyInputPacket {

--- a/src/test/java/hu/oe/nik/szfmv/visualization/DashboardTest.java
+++ b/src/test/java/hu/oe/nik/szfmv/visualization/DashboardTest.java
@@ -1,7 +1,6 @@
 package hu.oe.nik.szfmv.visualization;
 
 import hu.oe.nik.szfmv.automatedcar.bus.packets.input.ReadOnlyInputPacket;
-import hu.oe.nik.szfmv.automatedcar.bus.powertrain.PowertrainPacket;
 import hu.oe.nik.szfmv.automatedcar.bus.powertrain.ReadOnlyPowertrainPacket;
 import hu.oe.nik.szfmv.automatedcar.input.enums.GearEnum;
 import org.junit.Before;


### PR DESCRIPTION
# Added functionalities (with issue)

- Updated updateDisplayedValues so it takes ReadOnlyPowertrainPacket as a parameter and uses it to display the RPM and speed values on the analog meters #143
- Updated AutomatedCar so we can get the powertrain packet from it to the dashboard

# Other (test, documentation addition, refactor)

- Updated Dashboard test to also test the newly added getters
