### PR TITLE
Team5 Sprint3 Reverse Radar part3 (add to Dashboard + calculate distance)

### DIFF
--- a/src/main/java/hu/oe/nik/szfmv/Main.java
+++ b/src/main/java/hu/oe/nik/szfmv/Main.java
@@ -65,6 +65,7 @@ public class Main {
                         car.getInputValues(),
                         car.getPowertrainValues(),
                         car.getRoadSign(),
+                        car.getReverseRadarPacket(),
                         (int) Math.round(car.getX()), (int) Math.round(car.getY()));
                 gui.getDashboard().handleButtonPresses();
 
@@ -79,6 +80,7 @@ public class Main {
 
     /**
      * Creates the parking car NPCs.
+     *
      * @param w the world the cars are put into
      */
     private static void createParkingCarNPCs(World w) {

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/AutomatedCar.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/AutomatedCar.java
@@ -5,6 +5,7 @@ import hu.oe.nik.szfmv.automatedcar.bus.exception.MissingPacketException;
 import hu.oe.nik.szfmv.automatedcar.bus.packets.car.CarPacket;
 import hu.oe.nik.szfmv.automatedcar.bus.packets.input.ReadOnlyInputPacket;
 import hu.oe.nik.szfmv.automatedcar.bus.packets.powertrain.ReadOnlyPowertrainPacket;
+import hu.oe.nik.szfmv.automatedcar.bus.packets.reverseradar.ReadOnlyReverseRadarPacket;
 import hu.oe.nik.szfmv.automatedcar.bus.packets.roadsigndetection.ReadOnlyRoadSignDetectionPacket;
 import hu.oe.nik.szfmv.automatedcar.bus.packets.ultrasonicsensor.ReadOnlyUltrasonicSensorPacket;
 import hu.oe.nik.szfmv.automatedcar.sensors.UltrasonicSensor;
@@ -60,6 +61,7 @@ public class AutomatedCar extends WorldObject {
         new GearShift(virtualFunctionBus);
         new SensorsVisualizer(virtualFunctionBus);
         powertrainSystem = new PowertrainSystem(virtualFunctionBus);
+        reverseRadar = new ReverseRadar(virtualFunctionBus);
 
         new ACC(virtualFunctionBus);
         steeringSystem = new SteeringSystem(virtualFunctionBus);
@@ -69,7 +71,6 @@ public class AutomatedCar extends WorldObject {
         new FrontBackDetector(virtualFunctionBus, Detector.getDetector().getWorldObjects());
 
         new RoadSignDetection(virtualFunctionBus);
-        reverseRadar = new ReverseRadar(virtualFunctionBus);
         UltrasonicSensor.createUltrasonicSensors(this, virtualFunctionBus);
 
         new Driver(virtualFunctionBus);
@@ -159,6 +160,13 @@ public class AutomatedCar extends WorldObject {
         return virtualFunctionBus.powertrainPacket;
     }
 
+    /**
+     * Gets the reverse radar values as required by the dashboard.
+     * @return reverse radar packet containing the values that are displayed on the dashboard
+     */
+    public ReadOnlyReverseRadarPacket getReverseRadarPacket() {
+        return virtualFunctionBus.reverseRadarPacket;
+    }
 
     /**
      * Gets the roadsign closest to the car

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/AutomatedCar.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/AutomatedCar.java
@@ -61,7 +61,7 @@ public class AutomatedCar extends WorldObject {
         new GearShift(virtualFunctionBus);
         new SensorsVisualizer(virtualFunctionBus);
         powertrainSystem = new PowertrainSystem(virtualFunctionBus);
-        reverseRadar = new ReverseRadar(virtualFunctionBus);
+        reverseRadar = new ReverseRadar(virtualFunctionBus, getUltrasonicSensors());
 
         new ACC(virtualFunctionBus);
         steeringSystem = new SteeringSystem(virtualFunctionBus);

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/ReverseRadar.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/ReverseRadar.java
@@ -10,8 +10,8 @@ import org.apache.logging.log4j.Logger;
 public class ReverseRadar extends SystemComponent {
 
     private static final Logger LOGGER = LogManager.getLogger(ReverseRadar.class);
-    private static final double WARNING_VALUE = 0.4;
-    private static final double DANGER_VALUE = 0.8;
+    private static final double WARNING_VALUE = 0.8;
+    private static final double DANGER_VALUE = 0.4;
     private ReverseRadarPacket reverseRadarPacket;
     private ReverseRadarState reverseRadarState;
 
@@ -24,6 +24,7 @@ public class ReverseRadar extends SystemComponent {
         reverseRadarPacket = new ReverseRadarPacket();
         virtualFunctionBus.reverseRadarPacket = reverseRadarPacket;
         reverseRadarState = ReverseRadarState.OK;
+        reverseRadarPacket.setReverseRadarState(reverseRadarState);
     }
 
     @Override
@@ -38,7 +39,7 @@ public class ReverseRadar extends SystemComponent {
     private void activateReverseRadar() {
         reverseRadarPacket.setActivation(true);
         LOGGER.debug("Now the Reverse Radar activated: " + virtualFunctionBus.reverseRadarPacket.getActivation());
-        double objectDistance = Double.MAX_VALUE;
+        double objectDistance = 0.4;
 
         if (objectDistance >= 0.0 && objectDistance <= DANGER_VALUE) {
             reverseRadarState = ReverseRadarState.DANGER;

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/ReverseRadar.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/ReverseRadar.java
@@ -4,8 +4,13 @@ import hu.oe.nik.szfmv.automatedcar.bus.VirtualFunctionBus;
 import hu.oe.nik.szfmv.automatedcar.bus.exception.MissingPacketException;
 import hu.oe.nik.szfmv.automatedcar.bus.packets.reverseradar.ReverseRadarPacket;
 import hu.oe.nik.szfmv.automatedcar.input.enums.GearEnum;
+import hu.oe.nik.szfmv.automatedcar.sensors.UltrasonicSensor;
+import hu.oe.nik.szfmv.detector.classes.Detector;
+import hu.oe.nik.szfmv.environment.models.Collidable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.List;
 
 public class ReverseRadar extends SystemComponent {
 
@@ -14,13 +19,15 @@ public class ReverseRadar extends SystemComponent {
     private static final double DANGER_VALUE = 0.4;
     private ReverseRadarPacket reverseRadarPacket;
     private ReverseRadarState reverseRadarState;
+    private List<UltrasonicSensor> ultrasonicSensors;
 
     /**
      * @param virtualFunctionBus VirtualFunctuonBus parameter
      */
-    public ReverseRadar(VirtualFunctionBus virtualFunctionBus) {
+    public ReverseRadar(VirtualFunctionBus virtualFunctionBus, List<UltrasonicSensor> ultrasonicSensors) {
         super(virtualFunctionBus);
 
+        this.ultrasonicSensors = ultrasonicSensors;
         reverseRadarPacket = new ReverseRadarPacket();
         virtualFunctionBus.reverseRadarPacket = reverseRadarPacket;
         reverseRadarState = ReverseRadarState.OK;
@@ -39,7 +46,7 @@ public class ReverseRadar extends SystemComponent {
     private void activateReverseRadar() {
         reverseRadarPacket.setActivation(true);
         LOGGER.debug("Now the Reverse Radar activated: " + virtualFunctionBus.reverseRadarPacket.getActivation());
-        double objectDistance = 0.4;
+        double objectDistance = calculateNearestObjectDistance();
 
         if (objectDistance >= 0.0 && objectDistance <= DANGER_VALUE) {
             reverseRadarState = ReverseRadarState.DANGER;
@@ -57,5 +64,19 @@ public class ReverseRadar extends SystemComponent {
         LOGGER.debug("[Object distance: " + virtualFunctionBus.reverseRadarPacket.getDistance()
                 + "] and [Reverse Radar State is: " + virtualFunctionBus.reverseRadarPacket.getReverseRadarState()
                 + "]");
+    }
+
+    private double calculateNearestObjectDistance() {
+
+        double sensor1 = Double.MAX_VALUE;
+        double sensor2 = Double.MAX_VALUE;
+        if (ultrasonicSensors.get(2).getNearestObjectDistance() != null) {
+            sensor1 = ultrasonicSensors.get(2).getNearestObjectDistance();
+        }
+        if (ultrasonicSensors.get(3).getNearestObjectDistance() != null) {
+            sensor2 = ultrasonicSensors.get(3).getNearestObjectDistance();
+        }
+
+        return (sensor1 < sensor2) ? sensor1 : sensor2;
     }
 }

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/ReverseRadar.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/ReverseRadar.java
@@ -72,10 +72,10 @@ public class ReverseRadar extends SystemComponent {
         double sensor2 = Double.MAX_VALUE;
 
         if (ultrasonicSensors.get(backSensor1).getNearestObjectDistance() != null) {
-            sensor1 = ultrasonicSensors.get(backSensor1).getNearestObjectDistance();
+            sensor1 = (ultrasonicSensors.get(backSensor1).getNearestObjectDistance() / 100) - 1;
         }
         if (ultrasonicSensors.get(backSensor2).getNearestObjectDistance() != null) {
-            sensor2 = ultrasonicSensors.get(backSensor2).getNearestObjectDistance();
+            sensor2 = (ultrasonicSensors.get(backSensor2).getNearestObjectDistance() / 100) - 1;
         }
 
         return (sensor1 < sensor2) ? sensor1 : sensor2;

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/ReverseRadar.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/ReverseRadar.java
@@ -5,8 +5,6 @@ import hu.oe.nik.szfmv.automatedcar.bus.exception.MissingPacketException;
 import hu.oe.nik.szfmv.automatedcar.bus.packets.reverseradar.ReverseRadarPacket;
 import hu.oe.nik.szfmv.automatedcar.input.enums.GearEnum;
 import hu.oe.nik.szfmv.automatedcar.sensors.UltrasonicSensor;
-import hu.oe.nik.szfmv.detector.classes.Detector;
-import hu.oe.nik.szfmv.environment.models.Collidable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -23,6 +21,7 @@ public class ReverseRadar extends SystemComponent {
 
     /**
      * @param virtualFunctionBus VirtualFunctuonBus parameter
+     * @param ultrasonicSensors UltrasonicSensors ArrayList parameter
      */
     public ReverseRadar(VirtualFunctionBus virtualFunctionBus, List<UltrasonicSensor> ultrasonicSensors) {
         super(virtualFunctionBus);
@@ -67,14 +66,16 @@ public class ReverseRadar extends SystemComponent {
     }
 
     private double calculateNearestObjectDistance() {
-
+        final int backSensor1 = 2;
+        final int backSensor2 = 3;
         double sensor1 = Double.MAX_VALUE;
         double sensor2 = Double.MAX_VALUE;
-        if (ultrasonicSensors.get(2).getNearestObjectDistance() != null) {
-            sensor1 = ultrasonicSensors.get(2).getNearestObjectDistance();
+
+        if (ultrasonicSensors.get(backSensor1).getNearestObjectDistance() != null) {
+            sensor1 = ultrasonicSensors.get(backSensor1).getNearestObjectDistance();
         }
-        if (ultrasonicSensors.get(3).getNearestObjectDistance() != null) {
-            sensor2 = ultrasonicSensors.get(3).getNearestObjectDistance();
+        if (ultrasonicSensors.get(backSensor2).getNearestObjectDistance() != null) {
+            sensor2 = ultrasonicSensors.get(backSensor2).getNearestObjectDistance();
         }
 
         return (sensor1 < sensor2) ? sensor1 : sensor2;

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/RoadLaneDetector.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/RoadLaneDetector.java
@@ -99,7 +99,7 @@ public class RoadLaneDetector extends SystemComponent {
         for (Road r : roads) {
             if (r.getShape().intersects(car.getShape().getBounds2D().getX(), car.getShape().getBounds2D().getY(),
                     car.getShape().getBounds2D().getWidth(), car.getShape().getBounds2D().getHeight())) {
-                LOGGER.error("on the road fuck yeah");
+                LOGGER.debug("on the road fuck yeah");
                 return true;
             }
         }

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/RoadLaneDetector.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/RoadLaneDetector.java
@@ -99,7 +99,7 @@ public class RoadLaneDetector extends SystemComponent {
         for (Road r : roads) {
             if (r.getShape().intersects(car.getShape().getBounds2D().getX(), car.getShape().getBounds2D().getY(),
                     car.getShape().getBounds2D().getWidth(), car.getShape().getBounds2D().getHeight())) {
-                LOGGER.debug("on the road fuck yeah");
+                //LOGGER.debug("on the road fuck yeah");
                 return true;
             }
         }

--- a/src/main/java/hu/oe/nik/szfmv/visualization/Dashboard.java
+++ b/src/main/java/hu/oe/nik/szfmv/visualization/Dashboard.java
@@ -2,9 +2,11 @@ package hu.oe.nik.szfmv.visualization;
 
 import hu.oe.nik.szfmv.automatedcar.bus.packets.input.ReadOnlyInputPacket;
 import hu.oe.nik.szfmv.automatedcar.bus.packets.powertrain.ReadOnlyPowertrainPacket;
+import hu.oe.nik.szfmv.automatedcar.bus.packets.reverseradar.ReadOnlyReverseRadarPacket;
 import hu.oe.nik.szfmv.automatedcar.bus.packets.roadsigndetection.ReadOnlyRoadSignDetectionPacket;
 import hu.oe.nik.szfmv.automatedcar.input.InputHandler;
 import hu.oe.nik.szfmv.automatedcar.input.enums.GearEnum;
+import hu.oe.nik.szfmv.automatedcar.systemcomponents.ReverseRadarState;
 import hu.oe.nik.szfmv.environment.models.RoadSign;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -16,6 +18,7 @@ import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.text.DecimalFormat;
 import java.util.Objects;
 
 /**
@@ -71,22 +74,39 @@ public class Dashboard extends JPanel {
     private final int roadSignPanelX = 130;
     private final int roadSignPanelY = 180;
     private final int roadSignPanelWidth = 110;
-    private final int roadSignPanelHeight = 115;
+    private final int roadSignPanelHeight = 130;
     private final JPanel roadSignPanel = new JPanel();
     private final JLabel roadSignIcon = new JLabel();
     private final JLabel roadSignLabel = new JLabel();
 
     /**
+     * Reverse Radar
+     */
+    private final int reverseRadarPanelX = 55;
+    private final int reverseRadarPanelY = 123;
+    private final int reverseRadarPanelWidth = 130;
+    private final int reverseRadarPanelHeight = 30;
+
+    private final int reverseRadarLabelNameX = 100;
+    private final int reverseRadarLabelNameY = 110;
+    private final int reverseRadarLabelNameWidth = 50;
+    private final int reverseRadarLabelNameHeight = 10;
+
+    private final JPanel reverseRadarPanel = new JPanel();
+    private final JLabel reverseRadarLabelStatus = new JLabel();
+    private final JLabel revereRadarLabelDistance = new JLabel();
+
+    /**
      * Gear
      */
     private final int gearLabelX = 100;
-    private final int gearLabelY = 135;
+    private final int gearLabelY = 155;
     private final int gearLabelWidth = 40;
     private final int gearLabelHeight = 20;
     private final JLabel gearLabel = new JLabel();
 
     private final int gearValueLabelX = 135;
-    private final int gearValueLabelY = 135;
+    private final int gearValueLabelY = 155;
     private final int gearValueLabelWidth = 50;
     private final int gearValueLabelHeight = 20;
     private final JLabel gearValueLabel = new JLabel();
@@ -173,8 +193,8 @@ public class Dashboard extends JPanel {
     private String indexRightOn = "index_right_on.png";
     private boolean leftIndexState = false;
     private boolean rightIndexState = false;
-    private final int leftIndexX = 10;
-    private final int rightIndexX = 185;
+    private final int leftIndexX = 0;
+    private final int rightIndexX = 190;
     private final int indexY = 120;
     private final int imageH = 50;
     private final int imageW = 50;
@@ -209,15 +229,17 @@ public class Dashboard extends JPanel {
     /**
      * Update the displayed values
      *
-     * @param powertrainPacket Contains all the required values coming from the powertrain.
-     * @param inputPacket Contains all the required values coming from input.
-     * @param roadSignPacket Contains all the required values related to the last seen road sign.
-     * @param carX        is the X coordinate of the car object
-     * @param carY        is the Y coordinate of the car object
+     * @param powertrainPacket   Contains all the required values coming from the powertrain.
+     * @param inputPacket        Contains all the required values coming from input.
+     * @param roadSignPacket     Contains all the required values related to the last seen road sign.
+     * @param reverseRadarPacket Contains all the required values coming from the reverse radar.
+     * @param carX               is the X coordinate of the car object
+     * @param carY               is the Y coordinate of the car object
      */
     public void updateDisplayedValues(ReadOnlyInputPacket inputPacket,
                                       ReadOnlyPowertrainPacket powertrainPacket,
                                       ReadOnlyRoadSignDetectionPacket roadSignPacket,
+                                      ReadOnlyReverseRadarPacket reverseRadarPacket,
                                       int carX, int carY) {
         if (inputPacket != null) {
             updateProgressBars(inputPacket.getGasPedalPosition(), inputPacket.getBreakPedalPosition());
@@ -230,14 +252,44 @@ public class Dashboard extends JPanel {
             updateLaneKeepingIndicator(inputPacket.getLaneKeepingStatus());
         }
         if (powertrainPacket != null) {
-            updateAnalogMeters((int)powertrainPacket.getSpeed(), powertrainPacket.getRpm());
+            updateAnalogMeters((int) powertrainPacket.getSpeed(), powertrainPacket.getRpm());
             repaint();
         }
         if (roadSignPacket != null && roadSignPacket.getRoadSignToShowOnDashboard() != null) {
             displayRoadSign(roadSignPacket.getRoadSignToShowOnDashboard());
         }
+        if (reverseRadarPacket != null) {
+            displayReverseRadar(reverseRadarPacket.getActivation(), reverseRadarPacket.getReverseRadarState(),
+                    reverseRadarPacket.getDistance());
+        }
 
         updateCarPositionLabel(carX, carY);
+    }
+
+    private void displayReverseRadar(Boolean isActive, ReverseRadarState state, double distance) {
+        if (isActive) {
+            reverseRadarLabelStatus.setText("ON");
+            DecimalFormat value = new DecimalFormat("#.#");
+            revereRadarLabelDistance.setText(String.format("Distance: " + value.format(distance) + " m"));
+
+            switch (state) {
+                case OK:
+                    reverseRadarLabelStatus.setForeground(Color.GREEN);
+                    break;
+                case WARNING:
+                    reverseRadarLabelStatus.setForeground(Color.YELLOW);
+                    break;
+                case DANGER:
+                    reverseRadarLabelStatus.setForeground(Color.RED);
+                    break;
+                default:
+                    break;
+            }
+        } else {
+            reverseRadarLabelStatus.setText("OFF");
+            reverseRadarLabelStatus.setForeground(Color.BLACK);
+            revereRadarLabelDistance.setText("");
+        }
     }
 
     private void distanceDecreasePressed() {
@@ -376,6 +428,7 @@ public class Dashboard extends JPanel {
         initializePp();
         initializeAccStatePanel();
         initializeControlsText();
+        initializeReverseRadarPanel();
     }
 
     /**
@@ -384,17 +437,17 @@ public class Dashboard extends JPanel {
     private void initializeControlsText() {
         controlsText.setText(
                 "Gas: UP\n" +
-                "BREAK : DOWN\n" +
-                "Steering: LEFT, RIGHT\n" +
-                "Gear: W/S\n" +
-                "Index: 0,1\n" +
-                "LK: L\n" +
-                "PP: P\n" +
-                "ACC on: 5\n" +
-                "ACC dist.: T\n" +
-                "ACC speed: +/-\n" +
-                "Collision: 6\n" +
-                "Radar, Camera, Ultrasonic: 7,8,9");
+                        "BREAK : DOWN\n" +
+                        "Steering: LEFT, RIGHT\n" +
+                        "Gear: W/S\n" +
+                        "Index: 0,1\n" +
+                        "LK: L\n" +
+                        "PP: P\n" +
+                        "ACC on: 5\n" +
+                        "ACC dist.: T\n" +
+                        "ACC speed: +/-\n" +
+                        "Collision: 6\n" +
+                        "Radar, Camera, Ultrasonic: 7,8,9");
         controlsText.setBounds(controlsX, controlsY, controlsW, controlsH);
         controlsText.setFocusable(false);
         this.add(controlsText);
@@ -466,6 +519,7 @@ public class Dashboard extends JPanel {
 
     /**
      * Simulates keyboard press.
+     *
      * @param keyCode the keycode we want to simulate
      */
     private void simulateKeyPress(int keyCode) {
@@ -475,6 +529,7 @@ public class Dashboard extends JPanel {
 
     /**
      * Simulates keyboard release.
+     *
      * @param keyCode the keycode we want to simulate
      */
     private void simulateKeyRelease(int keyCode) {
@@ -507,6 +562,29 @@ public class Dashboard extends JPanel {
         roadSignPanel.add(roadSignIcon);
         roadSignLabel.setText("last road sign");
         add(roadSignPanel);
+    }
+
+    /**
+     * Initializes the reverse radar panel on the dashboard
+     */
+    private void initializeReverseRadarPanel() {
+        reverseRadarPanel.setBounds(reverseRadarPanelX, reverseRadarPanelY,
+                reverseRadarPanelWidth, reverseRadarPanelHeight);
+        reverseRadarPanel.setBorder(BorderFactory.createLineBorder(Color.BLACK, 1));
+
+        JLabel reverseRadarLabelName = new JLabel();
+        reverseRadarLabelName.setText("Radar");
+        reverseRadarLabelName.setBounds(reverseRadarLabelNameX, reverseRadarLabelNameY,
+                reverseRadarLabelNameWidth, reverseRadarLabelNameHeight);
+
+        revereRadarLabelDistance.setText("");
+
+        reverseRadarPanel.add(reverseRadarLabelStatus);
+        reverseRadarPanel.add(revereRadarLabelDistance);
+        reverseRadarPanel.setBackground(new Color(backgroundColor));
+
+        add(reverseRadarPanel);
+        add(reverseRadarLabelName);
     }
 
     /**

--- a/src/test/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/PowertrainSystemTest.java
+++ b/src/test/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/PowertrainSystemTest.java
@@ -1,7 +1,7 @@
 package hu.oe.nik.szfmv.automatedcar.systemcomponents;
 
 import hu.oe.nik.szfmv.automatedcar.bus.VirtualFunctionBus;
-import hu.oe.nik.szfmv.automatedcar.bus.powertrain.PowertrainTestPacket;
+import hu.oe.nik.szfmv.automatedcar.bus.packets.powertrain.PowertrainTestPacket;
 import hu.oe.nik.szfmv.automatedcar.input.enums.GearEnum;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/hu/oe/nik/szfmv/visualization/DashboardTest.java
+++ b/src/test/java/hu/oe/nik/szfmv/visualization/DashboardTest.java
@@ -2,8 +2,10 @@ package hu.oe.nik.szfmv.visualization;
 
 import hu.oe.nik.szfmv.automatedcar.bus.packets.input.ReadOnlyInputPacket;
 import hu.oe.nik.szfmv.automatedcar.bus.packets.powertrain.ReadOnlyPowertrainPacket;
+import hu.oe.nik.szfmv.automatedcar.bus.packets.reverseradar.ReadOnlyReverseRadarPacket;
 import hu.oe.nik.szfmv.automatedcar.bus.packets.roadsigndetection.ReadOnlyRoadSignDetectionPacket;
 import hu.oe.nik.szfmv.automatedcar.input.enums.GearEnum;
+import hu.oe.nik.szfmv.automatedcar.systemcomponents.ReverseRadarState;
 import hu.oe.nik.szfmv.environment.models.RoadSign;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +31,9 @@ public class DashboardTest {
     private boolean rpmGetterCalled = false;
     private boolean speedGetterCalled = false;
     private boolean roadSignGetterCalled = false;
+    private boolean radarDistanceCalled = false;
+    private boolean radarStateCalled = false;
+    private boolean radarActicationCalled = false;
 
     /**
      * Sets all the boolean values that indicate method calls to false before the tests are run.
@@ -46,6 +51,9 @@ public class DashboardTest {
         rpmGetterCalled = false;
         speedGetterCalled = false;
         roadSignGetterCalled = false;
+        radarDistanceCalled = false;
+        radarStateCalled = false;
+        radarActicationCalled = false;
     }
 
     /**
@@ -56,9 +64,10 @@ public class DashboardTest {
         InputPacketStub inputPacket = new InputPacketStub();
         PowertrainPacketStub powertrainPacket = new PowertrainPacketStub();
         RoadSignPacketStub roadSignPacketStub = new RoadSignPacketStub();
+        ReverseRadarStub reverseRadarStub = new ReverseRadarStub();
         int carX = 0;
         int carY = 0;
-        dashboard.updateDisplayedValues(inputPacket, powertrainPacket, roadSignPacketStub, carX, carY);
+        dashboard.updateDisplayedValues(inputPacket, powertrainPacket, roadSignPacketStub, reverseRadarStub, carX, carY);
 
         assertThat(gasPedalGetterCalled, is(true));
         assertThat(breakPedalGetterCalled, is(true));
@@ -73,6 +82,9 @@ public class DashboardTest {
         assertThat(rpmGetterCalled, is(true));
         assertThat(speedGetterCalled, is(true));
         assertThat(roadSignGetterCalled, is(true));
+        assertThat(radarActicationCalled, is(true));
+        assertThat(radarDistanceCalled, is(true));
+        assertThat(radarStateCalled, is(true));
     }
 
     class PowertrainPacketStub implements ReadOnlyPowertrainPacket {
@@ -86,6 +98,26 @@ public class DashboardTest {
         public double getSpeed() {
             speedGetterCalled = true;
             return 0;
+        }
+    }
+
+    class ReverseRadarStub implements ReadOnlyReverseRadarPacket {
+        @Override
+        public double getDistance() {
+            radarDistanceCalled = true;
+            return 0;
+        }
+
+        @Override
+        public ReverseRadarState getReverseRadarState() {
+            radarStateCalled = true;
+            return ReverseRadarState.DANGER;
+        }
+
+        @Override
+        public Boolean getActivation() {
+            radarActicationCalled = true;
+            return true;
         }
     }
 
@@ -180,7 +212,7 @@ public class DashboardTest {
         @Override
         public RoadSign getRoadSignToShowOnDashboard() {
             roadSignGetterCalled = true;
-            return new RoadSign(0,0, "2_crossroad_1.png");
+            return new RoadSign(0, 0, "2_crossroad_1.png");
         }
 
         @Override


### PR DESCRIPTION
Summary of changes and the sender team

# Fixed bugs (with referenced issue)

 - Fixing #405 issue 

# Added functionalities (with referenced issue)

 - Add reverse radar display to Dashboard (object distance from back of the car, and closeness warnings) Issues: #358 #357 
 - Implement object distance calculation when reversing. Issue: #359 

# (Breaking) changes (with referenced issue)

 - Some checkstyle and refactoring

# Other (test, documentation addition, refactor)
 - Add Reverse Radar unittest to DashboardTest in commit e09d70a
 - Update from team5 and master branch